### PR TITLE
Use request.mimetype instead of request.content_type

### DIFF
--- a/graphql_flask/graphqlview.py
+++ b/graphql_flask/graphqlview.py
@@ -172,4 +172,6 @@ class GraphQLView(View):
 
     @staticmethod
     def get_content_type(request):
-        return request.content_type
+        # We use mimetype here since we don't need the other
+        # information provided by content_type
+        return request.mimetype


### PR DESCRIPTION
request.content_type has encoding and other information associated with it. If we send in multipart/form-data, the content_type attribute is not just the mime type which is what we are interested in here, but
is a string of the form multipart/form-data;...

Please also see PR: https://github.com/graphql-python/graphql-flask/pull/1